### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ You need the rust toolchain, which is best installed through https://rustup.rs
 
 Clone this repository, then run
 
-    cargo install
+    cargo install --path PATH
+    
+where PATH is the path to the directory.  
 
 ### From the Snap store
 


### PR DESCRIPTION
Updated readme to avoid error:
"error: Using `cargo install` to install the binaries for the package in current working directory is no longer supported, use `cargo install --path .` instead. Use `cargo build` if you want to simply build the package."